### PR TITLE
v3.4.5

### DIFF
--- a/BeamMeUp/BeamMeUp.lua
+++ b/BeamMeUp/BeamMeUp.lua
@@ -64,9 +64,9 @@ function BMU.PortalHandlerKeyPress(index, favorite)
 		BMU.portToBMUGuildHouse()
 		return
 	end
-
-	-- Unlock Wayshrines (does not work in gamepad mode)
-	if index == 10 and not IsInGamepadPreferredMode() then
+	
+	-- Unlock Wayshrines
+	if index == 10 then
 		BMU.showDialogAutoUnlock()
 		return
 	end
@@ -115,16 +115,14 @@ function BMU.PortalHandlerKeyPress(index, favorite)
 			return
 		end
 		
-		if not IsInGamepadPreferredMode() then
-			-- open specific tab
-			SetGameCameraUIMode(true)
-			BMU.OpenTeleporter(false)
-			if index == 6 then
-				-- dungeon finder
-				BMU.createTableDungeons()
-			else
-				BMU.createTable({index=index})
-			end
+		-- open specific tab
+		SetGameCameraUIMode(true)
+		BMU.OpenTeleporter(false)
+		if index == 6 then
+			-- dungeon finder
+			BMU.createTableDungeons()
+		else
+			BMU.createTable({index=index})
 		end
 	else
 		-- window is shown

--- a/BeamMeUp/BeamMeUp.txt
+++ b/BeamMeUp/BeamMeUp.txt
@@ -3,8 +3,8 @@
 ## Author: DeadSoon, Gamer1986PAN
 ## APIVersion: 101037 101038
 ## SavedVariables: BeamMeUp_SV
-## Version: 3.4.4
-## AddOnVersion: 344
+## Version: 3.4.5
+## AddOnVersion: 345
 ## IsLibrary: false
 ## DependsOn: LibAddonMenu-2.0 LibCustomMenu LibSlashCommander LibZone
 ## OptionalDependsOn: BanditsUserInterface PortToFriendsHouse MorrowindStyleUI LibSets LibMapPing

--- a/BeamMeUp/GuildData.lua
+++ b/BeamMeUp/GuildData.lua
@@ -27,33 +27,32 @@ BMU_GuildData = {
     partnerGuilds = {
         ["EU Megaserver"] = {
             635942,			-- "In statu nascendi"			|@Alex183
-            570448,			-- "ShiZ laut Screenshot im Kommentarbereich - bisher leider keine Kontaktmöglichkeit
-            7871,			-- "Va Khaj Dar" laut Screenshot in Kommentarbereich - Beitrag im Forum gefunden und Kontaktaufnahme versucht
+            570448,			-- "ShiZ"                       |no contact yet
+              7871,			-- "Va Khaj Dar"                |no contact yet
             631764,			-- "Die magische Miezmuschel"	|@MiezeMelli
             661070,			-- "BMU Crossroad Alliance"		|@square252
             389326,			-- "Ork Mania"					|@OrkManiac4u
-            634734,			--  war ziemlich sicher Ork Mania II und nicht mehr existenzt
             677494,			-- "BMU Unofficial"				|@Kassec - unlisted aber Leader hat Discord
             418220,			-- "Frozen Lean Gang"			|@Vinc - über Discord angeschrieben
-            649984,			-- "Way to warm sands"			|@Ma'pyca 
-            701658,			-- "Armoored Rose"				|Discord-Name Лютобор Ingame noch rausfinden
+            649984,			-- "Way to warm sands"			|@Ma'pyca (ru)
+            701658,			-- "Armoored Rose"				|Discord-name Лютобор Ingame?
             704816,			-- "Reaper's Assasins"			|Original Leader @Hekate's_Realm -> Substitute Leader @BeamMeUp-Addon
-            489026,			-- "Magic Forest"				|@somedule Discord-Name Ingame noch rausfinden
+            489026,			-- "Magic Forest"				|@somedule Discord-name Ingame?
             713576,			-- "Spirits of the Lake"		|@TheMentor/@Th3M3nt0r
             430368,			-- "The Brotherhood of Askir"	|@Tianlein
             724742,			-- "BeamMeUp-Taverne"			|@Erzengel-Lucifer
-            18459,			-- "Chapions Guild"				|MagnumG Discord-Name Ingame noch rausfinden
-            732916,			-- "The Aimless Wanderers"		|Veritas Discord-Name Ingame noch rausfinden
-            163802,			-- "Fuego"						|Whasabi Discord-Name Ingame noch rausfinden
-            725690,			-- "Secret Squirrel Guild"		|
-            747096,			-- "BEER"						|pr0gress Discord-Name Ingame noch rausfinden
-            439872,			-- "Arkays Handelshof"			|
-            738288,			-- "Dragon's Imperium"			|
+            18459,			-- "Chapions Guild"				|MagnumG Discord-Name Ingame?
+            732916,			-- "The Aimless Wanderers"		|Veritas Discord-Name Ingame?
+            163802,			-- "Fuego"						|Whasabi Discord-Name Ingame?
+            725690,			-- "Secret Squirrel Guild"		|?
+            747096,			-- "BEER"						|pr0gress Discord-Name Ingame?
+            439872,			-- "Arkays Handelshof"			|?
+            738288,			-- "Dragon's Imperium"			|?
             756036,			-- "Die Ritter der Ananas"		|@XCrusaderX36
             742682,			-- "Grim Bastion"				|Ursprünglich SheldoRU, ✓Okc✓ Discord-Name Ingame noch rausfinden + nachfragen ob eintrag bestehen bleiben soll.
-            611168,			-- "Hermaeus Mora Army"			|triquetra Discord-Name Ingame noch rausfinden
-            527788,			-- "Akatosh Knights"			|likezed Discord-Name Ingame noch rausfinden
-            782574,			-- "Die reisenden Schatten"		|LaicosVK Discord-Name Ingame noch rausfinden
+            611168,			-- "Hermaeus Mora Army"			|triquetra Discord-Name Ingame?
+            527788,			-- "Akatosh Knights"			|likezed Discord-Name Ingame?
+            782574,			-- "Die reisenden Schatten"		|LaicosVK Discord-Name Ingame?
         },
         ["NA Megaserver"] = {
             698893,			-- "The Descendants"			|@ravenzwind

--- a/BeamMeUp/GuildData.lua
+++ b/BeamMeUp/GuildData.lua
@@ -10,70 +10,70 @@ BMU_GuildData = {
     -- official BMU guilds maintained by the addon developers (DeadSoon & Gamer1968PAN)
     officialGuilds = {
         ["EU Megaserver"] = {
-            569082,         -- "BeamMeUp"           | @DeadSoon
-            582568,         -- "BeamMeUp-Two"       | @
-            620882,
-            633582,
+            569082,         -- "BeamMeUp"					| @DeadSoon
+            582568,         -- "BeamMeUp-Two"				| @Gamer1986PAN
+            620882,			-- "BeamMeUp-Three"				| @Pandora959
+            633582,			-- "BeamMeUp-Four"				| @Sokarx
         },
         ["NA Megaserver"] = {
-            591705,         -- "BeamMeUp"           | @DeadSoon
-            666643,
-            708141,
-            720529,
+            591705,         -- "BeamMeUp"					| @DeadSoon
+            666643,         -- "BeamMeUp-Two"				| @Gamer1986PAN
+            708141,			-- "BeamMeUp-Three"				| @Pandora959
+            720529,			-- "BeamMeUp-Four"				| @Sokarx
         },
     },
 
     -- partner guilds that are independently maintained by other users
     partnerGuilds = {
         ["EU Megaserver"] = {
-            635942,
-            570448,
-            7871,
-            631764,
-            661070,
-            389326,
-            634734,
-            677494,
-            418220,
-            649984,
-            701658,
-            704816,
-            489026,
-            713576,
-            430368,
-            724742,
-            18459,
-            732916,
-            163802,
-            725690,
-            747096,
-            439872,
-            738288,
-            756036,
-            742682,
-            611168,
-            527788,
-            782574,
+            635942,			-- "In statu nascendi"			|@Alex183
+            570448,			-- "ShiZ laut Screenshot im Kommentarbereich - bisher leider keine Kontaktmöglichkeit
+            7871,			-- "Va Khaj Dar" laut Screenshot in Kommentarbereich - Beitrag im Forum gefunden und Kontaktaufnahme versucht
+            631764,			-- "Die magische Miezmuschel"	|@MiezeMelli
+            661070,			-- "BMU Crossroad Alliance"		|@square252
+            389326,			-- "Ork Mania"					|@OrkManiac4u
+            634734,			--  war ziemlich sicher Ork Mania II und nicht mehr existenzt
+            677494,			-- "BMU Unofficial"				|@Kassec - unlisted aber Leader hat Discord
+            418220,			-- "Frozen Lean Gang"			|@Vinc - über Discord angeschrieben
+            649984,			-- "Way to warm sands"			|@Ma'pyca 
+            701658,			-- "Armoored Rose"				|Discord-Name Лютобор Ingame noch rausfinden
+            704816,			-- "Reaper's Assasins"			|Original Leader @Hekate's_Realm -> Substitute Leader @BeamMeUp-Addon
+            489026,			-- "Magic Forest"				|@somedule Discord-Name Ingame noch rausfinden
+            713576,			-- "Spirits of the Lake"		|@TheMentor/@Th3M3nt0r
+            430368,			-- "The Brotherhood of Askir"	|@Tianlein
+            724742,			-- "BeamMeUp-Taverne"			|@Erzengel-Lucifer
+            18459,			-- "Chapions Guild"				|MagnumG Discord-Name Ingame noch rausfinden
+            732916,			-- "The Aimless Wanderers"		|Veritas Discord-Name Ingame noch rausfinden
+            163802,			-- "Fuego"						|Whasabi Discord-Name Ingame noch rausfinden
+            725690,			-- "Secret Squirrel Guild"		|
+            747096,			-- "BEER"						|pr0gress Discord-Name Ingame noch rausfinden
+            439872,			-- "Arkays Handelshof"			|
+            738288,			-- "Dragon's Imperium"			|
+            756036,			-- "Die Ritter der Ananas"		|@XCrusaderX36
+            742682,			-- "Grim Bastion"				|Ursprünglich SheldoRU, ✓Okc✓ Discord-Name Ingame noch rausfinden + nachfragen ob eintrag bestehen bleiben soll.
+            611168,			-- "Hermaeus Mora Army"			|triquetra Discord-Name Ingame noch rausfinden
+            527788,			-- "Akatosh Knights"			|likezed Discord-Name Ingame noch rausfinden
+            782574,			-- "Die reisenden Schatten"		|LaicosVK Discord-Name Ingame noch rausfinden
         },
         ["NA Megaserver"] = {
-            698893,
-            601183,
-            738065,
-            738317,
-            677323,
-            704951,
-            785051,
-            789007,
-            264915,
-            434691,
-            809511,
-            591467,
-            774767,
-            630613,
-            401657,
-            197803,
-            869871,
-            781641,
+            698893,			-- "The Descendants"			|@ravenzwind
+            601183,			-- "Dawn of Cthulhu				|@earthlyreaper
+            738065,			-- "Im Going On An Adventure"	|@KhuKhu
+            738317,			-- "KBMU"						|@Celinia
+            677323,			-- "Metrobank"					|@APHONlC
+            704951,			-- "Mara's Favor"				|@CassieAeri
+            785051,			-- ?
+            789007,			-- "Reaper's Assasins			|Original Leader @Hekate's_Realm -> Substitute Leader @Knifekill1984
+            264915,			-- "Ebonheart Merchant"			|@ - Discord User wurde gelöscht kein Hinweis auf Ingame-Name Gilde wird nicht angezeigt vermutlich inaktiv -
+            434691,			-- "Complete Souls"				|@Candalynn
+            809511,			-- "Zenithar’s Grace"			|@shortieFuse
+            591467,			-- "The Brotherhood of Askir"	|@Tianlein
+            774767,			-- "Circus Sideshow"			|@AnnaPython
+            630613,			-- "Seas of Oblivion"			|@Ocean Discord-Name Benutzer gelöscht Gilde nicht gelistet
+            401657,			-- "Zions of Chaos"				|@Shinigami Discord-Name Ingame noch rausfinden gilde aktuell nicht gelistet
+            197803,			-- "Celestial Rift"				|@Shiseida Discord-Name Ingame noch rausfinden gilde aktuell nicht gelistet
+            869871,			-- "Allegiance of Asgard"		|@joyousdeath Discord-Name Joy<3
+            781641,			-- "Pride of Ebon"				|@LilMuffin Discord-Name Ingame noch raufinden
         },
     }
 

--- a/BeamMeUp/TeleporterGlobals.lua
+++ b/BeamMeUp/TeleporterGlobals.lua
@@ -30,6 +30,9 @@ BMU.var = {
   BMUGuilds = BMU_GuildData.officialGuilds,
   partnerGuilds = BMU_GuildData.partnerGuilds,
   guildHouse = BMU_GuildData.guildHouses,
+
+  numFavoriteZones = 10,
+  numFavoritePlayers = 5,
 }
 
 -- libraries

--- a/BeamMeUp/core/List.lua
+++ b/BeamMeUp/core/List.lua
@@ -1852,8 +1852,7 @@ function BMU.clickOnZoneName(button, record)
 				}
 			else
 				-- number of favorites displayed in the context menu
-				local numFavorites = 10
-				for i=1, numFavorites, 1 do
+				for i=1, BMU.var.numFavoriteZones, 1 do
 					local favName = ""
 					if BMU.savedVarsServ.favoriteListZones[i] ~= nil then
 						favName = BMU.formatName(GetZoneNameById(BMU.savedVarsServ.favoriteListZones[i]), BMU.savedVarsAcc.formatZoneName)
@@ -2081,8 +2080,7 @@ function BMU.clickOnPlayerName(button, record)
 			}
 		else
 			-- number of favorites displayed in the context menu
-			local numFavorites = 5
-			for i=1, numFavorites, 1 do
+			for i=1, BMU.var.numFavoritePlayers, 1 do
 				local favName = ""
 				if BMU.savedVarsServ.favoriteListPlayers[i] ~= nil then
 					favName = BMU.savedVarsServ.favoriteListPlayers[i]
@@ -2452,19 +2450,17 @@ function BMU:tooltipTextEnter(control, text)
 end
 
 
+-- retrieves zone name from zoneId
+function BMU.getZoneIdFromZoneName(searchZoneName)
+	local libZoneData = BMU.LibZoneGivenZoneData
+	local zoneData = libZoneData[string.lower(BMU.lang)] or libZoneData["en"]
+	for zoneId, zoneName in pairs(zoneData) do
+		if string.lower(zoneName) == string.lower(searchZoneName) then
+			return zoneId
+		end
+	end
+end
+
+
 
 BMU.ListView = ListView
-
-
-------------- TEST INGAME STRINGS -------------
---[[
-local SI = BMU.SI
-local mkstr = ZO_CreateStringId
-
--- to consider
-mkstr(SI.TELE_UI_BTN_DUNGEON_FINDER, GetString(SI_CUSTOMERSERVICESUBMITFEEDBACKCATEGORIES10))					-- "Dungeons, Trials, & Arenas"
-mkstr(SI.TELE_KEYBINDING_TOGGLE_MAIN_DUNGEON_FINDER, GetString(SI_CUSTOMERSERVICESUBMITFEEDBACKCATEGORIES10))	-- "Dungeons, Trials, & Arenas"
-
---mkstr(SI.TELE_SETTINGS_USE_PAN_AND_ZOOM, GetString(SI_WORLD_MAP_ZOOM))								-- "Zoom"
---mkstr(SI.TELE_SETTINGS_USE_RALLY_POINT, GetString(SI_TOOLTIP_UNIT_MAP_RALLY_POINT))					-- "Group Rally Point"
---]]

--- a/BeamMeUp/core/TeleAppUI.lua
+++ b/BeamMeUp/core/TeleAppUI.lua
@@ -1928,7 +1928,7 @@ local function SetupUI()
 			
 		-- add dungeon difficulty toggle
 		if CanPlayerChangeGroupDifficulty() then
-			local menuIndex = AddCustomMenuItem(BMU.textures.dungeonDifficultyVeteran .. GetString(SI_DUNGEONDIFFICULTY2), function() BMU.setDungeonDifficulty(not ZO_ConvertToIsVeteranDifficulty(ZO_GetEffectiveDungeonDifficulty())) zo_callLater(function() BMU.createTableDungeons() end, 200) end, MENU_ADD_OPTION_CHECKBOX, nil, nil, nil, 5)
+			local menuIndex = AddCustomMenuItem(BMU.textures.dungeonDifficultyVeteran .. GetString(SI_DUNGEONDIFFICULTY2), function() BMU.setDungeonDifficulty(not ZO_ConvertToIsVeteranDifficulty(ZO_GetEffectiveDungeonDifficulty())) zo_callLater(function() BMU.createTableDungeons() end, 300) end, MENU_ADD_OPTION_CHECKBOX, nil, nil, nil, 5)
 			if ZO_ConvertToIsVeteranDifficulty(ZO_GetEffectiveDungeonDifficulty()) then
 				ZO_CheckButton_SetChecked(ZO_Menu.items[menuIndex].checkbox)
 			end

--- a/BeamMeUp/core/TeleSlashCommands.lua
+++ b/BeamMeUp/core/TeleSlashCommands.lua
@@ -46,30 +46,6 @@ function BMU.sc_toggleDebugMode()
 	else
 		BMU.debugMode = 1
 		BMU.printToChat("Debug mode enabled")
-		--[[
-		d("New slash commands available:")
-	
-		d("Printing of complete inventory (1): /bmu/debug/inv1")
-		SLASH_COMMANDS["/bmu/debug/inv1"] = BMU.sc_inv1
-	
-		d("Printing of complete inventory (2): /bmu/debug/inv2")
-		SLASH_COMMANDS["/bmu/debug/inv2"] = BMU.sc_inv2
-	
-		d("Printing of all POI in current zone: /bmu/debug/poi")
-		SLASH_COMMANDS["/bmu/debug/poi"] = BMU.sc_poi
-		
-		d("Testing library LibZone: /bmu/debug/libzone <zoneId>")
-		SLASH_COMMANDS["/bmu/debug/libzone"] = BMU.sc_testLibZone
-		
-		d("Initialization of Slash-Command-Porting: /bmu/debug/slashporting")
-		SLASH_COMMANDS["/bmu/debug/slashporting"] = BMU.sc_initializeSlashPorting
-		
-		d("Printing of all Quests and their location: /bmu/debug/quests")
-		SLASH_COMMANDS["/bmu/debug/quests"] = BMU.sc_printQuests
-		
-		-- refresh slash commands cache (for auto completing)
-		SLASH_COMMAND_AUTO_COMPLETE:InvalidateSlashCommandCache()
-		--]]
 	end
 end
 
@@ -78,35 +54,46 @@ function BMU.sc_switchLanguage(option)
 	if option == "de" or option == "en" or option == "fr" or option == "ru" or option == "es" or option == "pl" or option == "it" or option == "jp" or option == "br" or option == "kr" or option == "zh" then
 		SetCVar("language.2",option)
 	else
-		d("invalid language code")
-		d("only en, de, fr, ru, es, jp, pl, it, br, kr or zh allowed")
+		BMU.printToChat("invalid language code")
+		BMU.printToChat("only en, de, fr, ru, es, jp, pl, it, br, kr or zh allowed")
 	end
 end
 
 
+-- Examples:
+-- "/bmu/favorites/add/player 1 @Gamer1968PAN"
 function BMU.sc_addFavoritePlayer(option)
 	local options = BMU.sc_parseOptions(option)
-	local displayName = options[1]
-	local position = tonumber(options[2])
-	if displayName ~= nil and string.sub(displayName, 1, 1) == "@" and position ~= nil and position >= 1 and position <= 10 then
+	local position = tonumber(options[1])
+	local displayName = options[2]
+	
+	if displayName ~= nil and string.sub(displayName, 1, 1) == "@" and position ~= nil and position >= 1 and position <= BMU.var.numFavoritePlayers then
 		BMU.addFavoritePlayer(position, displayName)
 	else
-		d("invalid player name or slot")
-		d("player name has to begin with @... and slot must be a number between 1-10")
+		BMU.printToChat("invalid input")
+		BMU.printToChat("<favorite slot (1-5)>  <player name (@...)>")
 	end
 end
 
 
+-- Examples:
+-- "/bmu/favorites/add/zone 1 57"
+-- "/bmu/favorites/add/zone 1 Deshaan"
 function BMU.sc_addFavoriteZone(option)
 	local options = BMU.sc_parseOptions(option)
-	local zoneId = tonumber(options[1])
-	local position = tonumber(options[2])
+	local position = tonumber(options[1])
+	-- second parameter is number -> zoneId
+	-- or concat the params to one zone name (e.g. "High Isle" is incoming as 2 params)
+	local zoneNameOrId = tonumber(options[2]) or table.concat({unpack(options, 2)}, " ")
+
+	local zoneId = tonumber(zoneNameOrId) or BMU.getZoneIdFromZoneName(zoneNameOrId)
 	local zoneName = BMU.formatName(GetZoneNameById(zoneId), BMU.savedVarsAcc.formatZoneName)
-	if zoneName ~= nil and position ~= nil and position >= 1 and position <= 5 then
+	
+	if zoneName ~= nil and zoneName ~= "" and position ~= nil and position >= 1 and position <= BMU.var.numFavoriteZones then
 		BMU.addFavoriteZone(position, zoneId, zoneName)
 	else
-		d("invalid zone id or slot")
-		d("zone id must be exist and slot must be a number between 1-5")
+		BMU.printToChat("invalid input")
+		BMU.printToChat("<favorite slot (1-10)>  <zone (zoneId or zone name)>")
 	end
 end
 
@@ -114,7 +101,7 @@ end
 function BMU.sc_getCurrentZoneId()
 	local playersZoneIndex = GetUnitZoneIndex("player")
 	local playersZoneId = GetZoneId(playersZoneIndex)
-	d("Current zone id: " .. playersZoneId)
+	BMU.printToChat("Current zone id: " .. playersZoneId)
 end
 
 
@@ -122,7 +109,7 @@ function BMU.sc_customVoteUnanimous(option)
 	if option ~= nil and option ~= "" then
 		BeginGroupElection(GROUP_ELECTION_TYPE_GENERIC_UNANIMOUS, option)
 	else
-		d("invalid custom text")
+		BMU.printToChat("invalid custom text")
 	end
 end
 
@@ -131,7 +118,7 @@ function BMU.sc_customVoteSupermajority(option)
 	if option ~= nil and option ~= "" then
 		BeginGroupElection(GROUP_ELECTION_TYPE_GENERIC_SUPERMAJORITY, option)
 	else
-		d("invalid custom text")
+		BMU.printToChat("invalid custom text")
 	end
 end
 
@@ -140,7 +127,7 @@ function BMU.sc_customVoteSimplemajority(option)
 	if option ~= nil and option ~= "" then
 		BeginGroupElection(GROUP_ELECTION_TYPE_GENERIC_SIMPLEMAJORITY, option)
 	else
-		d("invalid custom text")
+		BMU.printToChat("invalid custom text")
 	end
 end
 


### PR DESCRIPTION
- fixed keybinds in gamepad mode
- zone favorites can be set via chat command by id or name, e.g. "/bmu/favorites/add/zone 1 Deshaan"
- show recall costs in the tooltip of the buttons in the dungeon tab (as with the "red" zones, travel is free when you interacting with a wayshrine)
- smaller improvements