### PR TITLE
Console readiness and bug fixes

### DIFF
--- a/.github/workflows/deploy-to-mods.yaml
+++ b/.github/workflows/deploy-to-mods.yaml
@@ -3,7 +3,7 @@ name:  Deploy Addon
 on:
   push:
     branches:
-    - console/*
+    - console/v*
 
 jobs:
   release:
@@ -68,6 +68,18 @@ jobs:
 
           # create zip
           (cd /tmp && zip -r "$REPO_FOLDER/${{ env.ZIP_FULL_NAME }}" "${{ env.ADDON_NAME }}")
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: "${{ env.ADDON_VERSION }}"
+          commit: ${{ github.ref }}
+          tag: "${{ env.ADDON_VERSION }}"
+          artifacts: "${{ github.workspace }}/${{ env.ADDON_NAME }}/${{ env.ZIP_FULL_NAME }}"
+          artifactContentType: application/zip
+          bodyFile: latest_changes.md
+          allowUpdates: true
+          makeLatest: true
 
       - name: Extract latest changelog entry
         run: |

--- a/BeamMeUp.addon.template
+++ b/BeamMeUp.addon.template
@@ -6,7 +6,7 @@
 ## Version: ${ADDON_VERSION}
 ## AddOnVersion: ${ADDON_FORMATTED_VERSION}
 ## IsLibrary: false
-## ConsoleDependsOn: LibVotans
+## ConsoleDependsOn: LibHarvensAddonSettings
 ## DependsOn: LibAddonMenu-2.0>=41 LibScrollableMenu>=020401 LibZone>=0895
 ## OptionalDependsOn: LibCustomMenu LibSlashCommander LibSets LibMapPing LibChatMenuButton PortToFriendsHouse BanditsUserInterface MorrowindStyleUI
 

--- a/BeamMeUp/BeamMeUp.addon
+++ b/BeamMeUp/BeamMeUp.addon
@@ -6,7 +6,7 @@
 ## Version: 4.0.0
 ## AddOnVersion: 400
 ## IsLibrary: false
-## ConsoleDependsOn: LibVotans
+## ConsoleDependsOn: LibHarvensAddonSettings
 ## DependsOn: LibAddonMenu-2.0>=41 LibScrollableMenu>=020401 LibZone>=0895
 ## OptionalDependsOn: LibCustomMenu LibSlashCommander LibSets LibMapPing LibChatMenuButton PortToFriendsHouse BanditsUserInterface MorrowindStyleUI
 

--- a/BeamMeUp/Gamepad/IsJustaBmuGamepadPlugin.lua
+++ b/BeamMeUp/Gamepad/IsJustaBmuGamepadPlugin.lua
@@ -1,113 +1,3 @@
---[[
-need to fix map changing on open and close
-need to fix group member names
-need to fix on open select first entry
-
-Comment ore remove  -- { categoryList.lua line 332 d( 'Please let me know ...}
-
--- Next
-
-
--- Currrent
-- - - 1.4.2
-○ added compatibility support to prevent showing when a minimap is in use.
-
-- - - 1.4.1
-○ Fixed Gamepad BMU opening in keyboard mode.
-
-- - - 1.4
-○ Added 2 options, found in Beam me up Settings.
-1. "Open BeamMeUp when the map is opened". This causes it to open the gampade world map info on map open.
-2. "Keep BeamMeUp open". Always changes the tab back to Beam Me Up on map close
-
-- - - 1.3.6
-○ fixed error /IsJustaBmuGamepadPlugin/core/entryData.lua:73: table index is nil
-○ fixed error /IsJustaBmuGamepadPlugin/core/categoryList.lua:502: operator + is not supported for nil + number
-○ removed Port To Friends chat output
-
-- - - 1.3.5
-○ fixed some houses randomly getting sorted in with zones
-○ Changed how teleport is handled with PTF
-○ changed how stats are updatd. no longer updated on attempt to travel but, on player activated if jump was sucsessful.
-
-- - - 1.3.4
-○ removed debug output from teleportList:Refresh
-
-- - - 1.3.3
-○ fixed error "IsJustaBmuGamepadPlugin.lua:124: table index is nil"
-
-- - - 1.3.2
-○ fixed Notification replacing "Out-of-Date Add-Ons"
-
-- - - 1.3.1
-○ Port to friends now sorts the houses under headers of the owners
-
-- - - 1.3
-○ Updated API to 101042
-○ Fixed it so user's character does not show up in player social options
-○ Added show "Port To Friends" window option to "Port To Friends" category and house list options.
-- on closing, returns to the pervious list.
-○ The owners name now shows below the house name in "Port To Friends" list.
-○ Fixed "Port To Friends" not porting to the correct house.
-○ "Invite to guild" should now only show guilds you "can" invite too. You can't invite to a guild they are already a member of.
-
-- - - 1.2.6
-○ removed debug output
-
-- - - 1.2.5
-○ Test fix for preventing error "globalapi.lua:202: in function 'zo_iconFormat'"
-	On travel, the maps list header was not being disabled, which kept it's left/right keybinds active.
-
-- - - 1.2.4
-○ fixed locations not panning if on the same map.
-	for example. If currently over 1 Craglorn trial and you move on the list and stop at another Craglorn trial, It would remain on the previous trial.
-- - - 1.2.3
-○ fixed BMU guild list not showing guild names.
-
-- - - 1.2.2
-○ fixed the incorrect Notification being used.
-
-- - - 1.2.1
-○ disabled the test category
-
-- - - 1.2
-○ improved list functionality to help avoid auto selecting the wrong entry on refresh
--- also, on first entering the teleport list, the first entry should now have proper options available.
-○ fixed favorites name color
-○ added list narration support
-○ synced up some additional BMU settings.
--- current zone always on top. show number of players in zone.
-○ BMU favorites added in keyboard mode should now be removed if removed in gamepad mode
--- Favorites added in gamepad mode will still not be shown in keyboard mode. 
--- That will not happen due to the way favorites are added in gamepad mode.
--- In keyboard mode, favorites are added based on available favorite slots. 
--- In gamepad mode they are added by, zone or player, name.
-○ added the auto-wayshrine unlock feature of BeamMeUp
-○
-○
-
-- - - 1.1
-○ fixed missing strings in survey category options filters
-○ changed single checkboxes of survey types to a multi-select dropdown
-○
-○
-- - - 0.1
-○
-
-added travel options
-
-need to fix dungeon travel
-
-test category filter options
-test player options
-
-SI_BMU_GAMEPAD_MANAGE_FAVORITES = 'Manage Favorites',
-
-fix quick select category causing select spam
-]]
-
-
-
 ---------------------------------------------------------------------------------------------------------------
 --
 ---------------------------------------------------------------------------------------------------------------
@@ -155,6 +45,11 @@ end
 ---------------------------------------------------------------------------------------------------------------
 local addon = ZO_DeferredInitializingObject:Subclass()
 BMU.IJA = addon
+
+BMU.IJA.gameplayInfo = {
+  newInputType = nil,
+  eventCode = nil
+}
 
 local BMU = BMU
 local em = EVENT_MANAGER
@@ -579,10 +474,6 @@ function addon:RegisterEvents()
 	em:RegisterForEvent(self.name, EVENT_QUEST_ADDED, refreshOnEvent)
 	em:RegisterForEvent(self.name, EVENT_QUEST_REMOVED, refreshOnEvent)
 	em:RegisterForEvent(self.name, EVENT_QUEST_CONDITION_COUNTER_CHANGED, refreshOnEvent)
-	
-	em:RegisterForEvent(self.name, EVENT_GAMEPAD_PREFERRED_MODE_CHANGED, function(eventCode, newInputType)
-      ZO_Alert(UI_ALERT_CATEGORY_ALERT, SOUNDS.NEW_NOTIFICATION, GetString(SI_BMU_GAMEPAD_PLEASE_RELOAD))
-  end)
 
 	local trackedItems = {
 		[SPECIALIZED_ITEMTYPE_TROPHY_SURVEY_REPORT] = true,

--- a/BeamMeUp/Gamepad/IsJustaBmuGamepadPlugin.lua
+++ b/BeamMeUp/Gamepad/IsJustaBmuGamepadPlugin.lua
@@ -46,11 +46,6 @@ end
 local addon = ZO_DeferredInitializingObject:Subclass()
 BMU.IJA = addon
 
-BMU.IJA.gameplayInfo = {
-  newInputType = nil,
-  eventCode = nil
-}
-
 local BMU = BMU
 local em = EVENT_MANAGER
 local cm = CALLBACK_MANAGER

--- a/BeamMeUp/Gamepad/core/categoryList.lua
+++ b/BeamMeUp/Gamepad/core/categoryList.lua
@@ -458,11 +458,12 @@ function categoryList:BuildOptionsList()
 	self.conditionResults = {}
 
 	self:BuildPortToFriendOption()
+	local settingsGroupId = self:AddOptionTemplateGroup(function() return GetString(SI_GAME_MENU_SETTINGS) end)
 	local filtersGroupId = self:AddOptionTemplateGroup(function() return GetString(SI_GAMEPAD_CRAFTING_OPTIONS_FILTERS) end)
 --	self:BuildAutoUnlockOptions(filtersGroupId)
 	self:BuildMainCategroyOptions(filtersGroupId)
 	self:BuildItemsCategoryOptions(filtersGroupId)
-	self:BuildDungeonsCategoryOptions(filtersGroupId)
+	self:BuildDungeonsCategoryOptions(filtersGroupId, settingsGroupId)
 	self:BuildDelvesCategoryOptions(filtersGroupId)
 end
 
@@ -620,12 +621,22 @@ function categoryList:BuildItemsCategoryOptions(groupId)
 	self:AddOptionTemplate(filtersGroupId, function() return self:BuildMultiSelectDropdown(SI_SPECIALIZEDITEMTYPE101, nil, filterData, icon, areSurveysActive) end, conditionFunction)
 end
 
-function categoryList:BuildDungeonsCategoryOptions(groupId)
+function categoryList:BuildDungeonsCategoryOptions(groupId, settingsGroupId)
 	local function conditionFunction()
 		local categoryData = self:GetTargetData()
 		if not categoryData then return false end
 		return categoryData.categoryType == CATEGORY_TYPE_DUNGEON
 	end
+	local settingsData = {
+    {
+			filterName = GetString(SI_TELE_UI_TOGGLE_ACRONYM),
+			callback = function(data)
+				self:ToggleBMUSettingByKey('toggleShowAcronymUpdateName', data.checked, "dungeonFinder")
+			end,
+			checked = getTeleporterSettingByKey('toggleShowAcronymUpdateName', "dungeonFinder"),
+		}
+	}
+	
 	local filterData = {
 		{
 			filterName = GetString(SI_TELE_UI_TOGGLE_ENDLESS_DUNGEONS),
@@ -663,6 +674,11 @@ function categoryList:BuildDungeonsCategoryOptions(groupId)
 			checked = getTeleporterSettingByKey('showDungeons', "dungeonFinder"),
 		},
 	}
+	if settingsGroupId then
+    for settingsIndex, currentSetting in ipairs(settingsData) do
+      self:AddOptionTemplate(settingsGroupId, function() return self:BuildCheckbox(SI_GAME_MENU_SETTINGS, label, currentSetting, icon) end, conditionFunction)
+    end
+	end
 	for filterIndex, currentFilter in ipairs(filterData) do
 		self:AddOptionTemplate(groupId, function() return self:BuildCheckbox(SI_GAMEPAD_CRAFTING_OPTIONS_FILTERS, label, currentFilter, icon) end, conditionFunction)
 	end

--- a/BeamMeUp/Gamepad/core/dialogues.lua
+++ b/BeamMeUp/Gamepad/core/dialogues.lua
@@ -25,7 +25,7 @@ ZO_Dialogs_RegisterCustomDialog("BMU_GAMEPAD_SOCIAL_OPTIONS_DIALOG",
 		dialog:setupFunc()
 	end,
 	finishedCallback = function(dialog)
-		if finishedCallback then
+		if finishedCallback and type(finishedCallback) == "function" then
 			finishedCallback(dialog)
 		end
 	end,
@@ -140,7 +140,7 @@ ZO_Dialogs_RegisterCustomDialog("BMU_GAMEPAD_MANAGE_FAVORITES_DIALOG",
 		allowShowOnNextScene = true,
 	},
 	finishedCallback = function(dialog)
-		if finishedCallback then
+		if finishedCallback and type(finishedCallback) == "function" then
 			finishedCallback(dialog)
 		end
 	end,

--- a/BeamMeUp/Gamepad/core/entryData.lua
+++ b/BeamMeUp/Gamepad/core/entryData.lua
@@ -34,47 +34,6 @@ local CATEGORY_TYPE_TEST		= 10
 
 local CURRENT_CATEGORY_TYPE = 0
 
---[[
-local defaultHeaders = {
-	[1] = getHeaderString('ENTRY', 1),
-	[2] = getHeaderString('ENTRY', 2),
-	[3] = getHeaderString('ENTRY', 3),
-	[4] = GetString(SI_TELE_UI_TOGGLE_GROUP_DUNGEONS),
-	[5] = GetString(SI_TELE_UI_TOGGLE_TRIALS),
-	[6] = getHeaderString('ENTRY', 2),
-	[7] = GetString(SI_TELE_UI_TOGGLE_GROUP_ARENAS),
-	[8] = GetString(SI_TELE_UI_TOGGLE_ARENAS),
-	[9] = getHeaderString('ENTRY', 9),
-	[BMU.ZONE_CATEGORY_OVERLAND] = getHeaderString('ENTRY', 9),
-}
-
-
-BMU.ZONE_CATEGORY_UNKNOWN = 0
-BMU.ZONE_CATEGORY_DELVE = 1
-BMU.ZONE_CATEGORY_PUBDUNGEON = 2
-BMU.ZONE_CATEGORY_HOUSE = 3
-BMU.ZONE_CATEGORY_GRPDUNGEON = 4
-BMU.ZONE_CATEGORY_TRAIL = 5
-BMU.ZONE_CATEGORY_ENDLESSD = 6
-BMU.ZONE_CATEGORY_GRPZONES = 7
-BMU.ZONE_CATEGORY_GRPARENA = 8
-BMU.ZONE_CATEGORY_SOLOARENA = 9
-BMU.ZONE_CATEGORY_OVERLAND = 100
-
-BMU.blacklistHouses[zoneId]
-
-local zoneCategory = {
-	[1306] = BMU.ZONE_CATEGORY_HOUSE,
-	[1468] = BMU.ZONE_CATEGORY_HOUSE,
-}
-local function updateZoneCategory(entry)
-	local zoneId = entry.zoneId
-	return BMU.blacklistHouses[zoneId] and BMU.ZONE_CATEGORY_HOUSE or
-	entry.category or BMU.ZONE_CATEGORY_UNKNOWN
-end
-
-]]
-
 local defaultHeaders = {
 	[SORT_ORDER_FAVORITE]			= GetString(SI_TELE_UI_SUBMENU_FAVORITES), -- Favorites
 	[BMU.ZONE_CATEGORY_UNKNOWN]		= GetString(SI_CHAT_CHANNEL_NAME_ZONE), -- Zone

--- a/BeamMeUp/Gamepad/core/telportList.lua
+++ b/BeamMeUp/Gamepad/core/telportList.lua
@@ -130,7 +130,7 @@ function teleportList:InitializeKeybindDescriptor()
 
 				if targetData then
 					if targetData.categoryType == CATEGORY_TYPE_BMU then
-						ZO_LinkHandler_OnLinkClicked("|H1:guild:" .. targetData.guildId .. "|hGuild|h", 1, nil)
+						GUILD_BROWSER_GAMEPAD:ShowGuildInfo(targetData.guildId)
 					else
 						if targetData.numberPlayers and BMU.savedVarsAcc.zoneOnceOnly then
 							local categoryList = self.owner.categoryList

--- a/BeamMeUp/Gamepad/i18n/en.lua
+++ b/BeamMeUp/Gamepad/i18n/en.lua
@@ -11,6 +11,7 @@ local strings = {
 	SI_TELE_UI_TOGGLE_TRIALS            = "Show trials",
 	SI_TELE_UI_TOGGLE_ENDLESS_DUNGEONS  = "Show Endless Archive",
 	
+	
 	SI_BMU_GAMEPAD_PAN						= "Focus in on map pin",
 	SI_BMU_GAMEPAD_PAN_TOOLTIP				= "Enabled: If a destination has a map pin, on selection the map will auto-focus in on the pin.",
 	

--- a/BeamMeUp/GuildData.lua
+++ b/BeamMeUp/GuildData.lua
@@ -5,6 +5,7 @@ BMU_GUILD_DATA = {
         -- per server displayName and houseId
         ["EU Megaserver"]	= {"@DeadSoon", 81},
         ["NA Megaserver"]	= {"@Ladytala", 47},
+        ["XB1live"]       = {"@Saranicole1980", 90}
     },
     
     -- official BMU guilds maintained by the addon developers (DeadSoon & Gamer1968PAN)
@@ -21,6 +22,10 @@ BMU_GUILD_DATA = {
             708141,			-- "BeamMeUp-Three"				| @Pandora959
             720529,			-- "BeamMeUp-Four"				| @Sokarx
         },
+        ["XB1live"] = {
+            1273043,     -- "BeamMeUp-Soon"
+        
+        }
     },
 
     -- partner guilds that are independently maintained by other users
@@ -101,6 +106,7 @@ BMU_GUILD_DATA = {
             986137,         -- "Don't Talk to Me"           |@Cadence_Nightingale discord neurotopia
             978203,         -- "The Daedric Wastelanders"   |@K1LL3R-Cfrags discord shade_k1ller
         },
+        ["XB1live"] = {},
     }
 
 }

--- a/BeamMeUp/core/TeleAppUI.lua
+++ b/BeamMeUp/core/TeleAppUI.lua
@@ -2129,7 +2129,7 @@ end
 function BMU.TeleporterSetupUI(addOnName)
 	if appName ~= addOnName then return end
 		addOnName = appName .. " - Teleporter"
-		if BMU_IsNotKeyboard() then
+		if BMU_IsNotKeyboard() and CS ~= nil then
       CS.SetupOptionsMenu(addOnName)
 		else
 		  BMU.SetupOptionsMenu(addOnName)


### PR DESCRIPTION
Changes:
* Use LibHarvensAddonSettings since that is what is available on PC and the console mod doesn't really care what is in the addon file with respect to dependencies
* Remove ZO_Alert on Gamepad mode changed
* Add XBox Guild info
* Fix console bug with opening guild info
* Fix intermittent bug with survey reports
* Adds the toggle for acronyms in the dungeon filters view in addition to the settings
* Adds deployment automation for the console mod, which will also create a tagged release to generate history, making it harder to challenge the ownership of the console mod by this repository

Note that I have it currently set to name the tagged release in the format v4.0.1.001
I can set it to prefix that name with "console-" if you prefer