### PR TITLE
4.0.2 Console and miscellaneous fixes

### DIFF
--- a/.github/workflows/deploy-to-mods.yaml
+++ b/.github/workflows/deploy-to-mods.yaml
@@ -23,6 +23,10 @@ jobs:
           sparse-checkout: |
             LibZone
           sparse-checkout-cone-mode: false
+
+      - name: Remove .git
+        run: |
+          rm -rf BeamMeUp/Console/lib/LibZone/.git
           
       - name: Get branch name as version
         id: semver

--- a/.github/workflows/deploy-to-mods.yaml
+++ b/.github/workflows/deploy-to-mods.yaml
@@ -69,6 +69,11 @@ jobs:
           # create zip
           (cd /tmp && zip -r "$REPO_FOLDER/${{ env.ZIP_FULL_NAME }}" "${{ env.ADDON_NAME }}")
 
+      - name: Extract latest changelog entry
+        run: |
+          awk '/^## / { if (!found) { found=1; print; next } else { exit } } found' CHANGELOG.md > latest_changes.md
+          cat latest_changes.md
+
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
@@ -80,11 +85,6 @@ jobs:
           bodyFile: latest_changes.md
           allowUpdates: true
           makeLatest: true
-
-      - name: Extract latest changelog entry
-        run: |
-          awk '/^## / { if (!found) { found=1; print; next } else { exit } } found' CHANGELOG.md > latest_changes.md
-          cat latest_changes.md
 
       - name: Upload to BNET
         uses: m00nyONE/bnet-upload@main

--- a/.github/workflows/deploy-to-mods.yaml
+++ b/.github/workflows/deploy-to-mods.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Remove .git
         run: |
-          rm -rf BeamMeUp/Console/lib/LibZone/.git
+          rm -rf BeamMeUp/Console/lib/.git
           
       - name: Get branch name as version
         id: semver

--- a/.github/workflows/deploy-to-mods.yaml
+++ b/.github/workflows/deploy-to-mods.yaml
@@ -75,13 +75,14 @@ jobs:
 
       - name: Extract latest changelog entry
         run: |
-          awk '/^## / { if (!found) { found=1; print; next } else { exit } } found' CHANGELOG.md > latest_changes.md
+          echo "Console Release Only" > latest_changes.md
+          awk '/^## / { if (!found) { found=1; print; next } else { exit } } found' CHANGELOG.md >> latest_changes.md
           cat latest_changes.md
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          name: "${{ env.ADDON_VERSION }}"
+          name: "Console Version Only - ${{ env.ADDON_VERSION }}"
           commit: ${{ github.ref }}
           tag: "${{ env.ADDON_VERSION }}"
           artifacts: "${{ github.workspace }}/${{ env.ADDON_NAME }}/${{ env.ZIP_FULL_NAME }}"

--- a/BeamMeUp.addon.template
+++ b/BeamMeUp.addon.template
@@ -8,7 +8,7 @@
 ## IsLibrary: false
 ## ConsoleDependsOn: LibHarvensAddonSettings
 ## DependsOn: LibAddonMenu-2.0>=41
-## PCDependsOn: LibScrollableMenu LibZone
+## PCDependsOn: LibScrollableMenu LibZone>=0895
 ## OptionalDependsOn: LibCustomMenu LibSlashCommander LibSets LibMapPing LibChatMenuButton PortToFriendsHouse BanditsUserInterface MorrowindStyleUI
 
 ## Core translation files

--- a/BeamMeUp.addon.template
+++ b/BeamMeUp.addon.template
@@ -29,10 +29,13 @@ Gamepad/globals.lua
 
 ## LibZone
 Console/lib/LibZone/LibZone_Constants.lua
+
+##LibZone API functions
+Console/lib/LibZone/LibZone.lua
+
+##LibZone preloaded zonedata and names
 Console/lib/LibZone/LibZone_Data.lua
 Console/lib/LibZone/LibZone_GeoData.lua
-Console/lib/LibZone/LibZone_Maps.xlsx
-Console/lib/LibZone/LibZone.lua
 
 Gamepad/IsJustaBmuGamepadPlugin.lua
 Gamepad/IsJustaBmuGamepadPlugin.xml

--- a/BeamMeUp.addon.template
+++ b/BeamMeUp.addon.template
@@ -7,8 +7,8 @@
 ## AddOnVersion: ${ADDON_FORMATTED_VERSION}
 ## IsLibrary: false
 ## ConsoleDependsOn: LibHarvensAddonSettings
-## DependsOn: LibAddonMenu-2.0>=41 LibZone>=0895
-## PCDependsOn: LibScrollableMenu
+## DependsOn: LibAddonMenu-2.0>=41
+## PCDependsOn: LibScrollableMenu LibZone
 ## OptionalDependsOn: LibCustomMenu LibSlashCommander LibSets LibMapPing LibChatMenuButton PortToFriendsHouse BanditsUserInterface MorrowindStyleUI
 
 ## Core translation files

--- a/BeamMeUp.addon.template
+++ b/BeamMeUp.addon.template
@@ -16,6 +16,16 @@ core/SI.lua
 localization/EN.lua
 localization/$(language).lua
 
+## LibZone
+Console/lib/LibZone/LibZone_Constants.lua
+
+##LibZone API functions
+Console/lib/LibZone/LibZone.lua
+
+##LibZone preloaded zonedata and names
+Console/lib/LibZone/LibZone_Data.lua
+Console/lib/LibZone/LibZone_GeoData.lua
+
 ## Globals / data sets
 GuildData.lua
 TeleporterGlobals.lua
@@ -26,16 +36,6 @@ Gamepad/i18n/en.lua
 Gamepad/i18n/$(language).lua
 
 Gamepad/globals.lua
-
-## LibZone
-Console/lib/LibZone/LibZone_Constants.lua
-
-##LibZone API functions
-Console/lib/LibZone/LibZone.lua
-
-##LibZone preloaded zonedata and names
-Console/lib/LibZone/LibZone_Data.lua
-Console/lib/LibZone/LibZone_GeoData.lua
 
 Gamepad/IsJustaBmuGamepadPlugin.lua
 Gamepad/IsJustaBmuGamepadPlugin.xml

--- a/BeamMeUp/core/TeleAppUI.lua
+++ b/BeamMeUp/core/TeleAppUI.lua
@@ -2144,7 +2144,7 @@ end
 function BMU.TeleporterSetupUI(addOnName)
 	if appName ~= addOnName then return end
 		addOnName = appName .. " - Teleporter"
-		if BMU_IsNotKeyboard() and CS ~= nil then
+		if IsConsoleUI() and CS ~= nil then
       CS.SetupOptionsMenu(addOnName)
 		else
 		  BMU.SetupOptionsMenu(addOnName)

--- a/BeamMeUp/core/TeleAppUI.lua
+++ b/BeamMeUp/core/TeleAppUI.lua
@@ -501,28 +501,30 @@ local function SetupUI()
 		else
 			-- do it the old way
 			-- Texture
-			BMU_chatButtonTex = wm:CreateControl("Teleporter_CHAT_MENU_BUTTON", zo_ChatWindow, CT_TEXTURE) --CHG251229 Baertram Performance improvedment for multiple used variable
-            BMU.chatButtonTex = BMU_chatButtonTex --INS251229 Baertram
-			BMU_chatButtonTex:SetDimensions(33, 33)  --CHG251229 Baertram
-			BMU_chatButtonTex:SetAnchor(TOPRIGHT, zo_ChatWindow, TOPRIGHT, -40 - BMU_svAcc.chatButtonHorizontalOffset, 6) --CHG251229 Baertram
-			BMU_chatButtonTex:SetTexture(BMU_textures_wayshrineBtn) --CHG251229 Baertram
-			BMU_chatButtonTex:SetMouseEnabled(true) --CHG251229 Baertram
-			BMU_chatButtonTex:SetDrawLayer(2) --CHG251229 Baertram
-			--Handlers
-			BMU_chatButtonTex:SetHandler("OnMouseUp", function(self, button) --CHG251229 Baertram
-				if button ~= MOUSE_BUTTON_INDEX_LEFT then return end  --INS BAERTRAM20260124
-				BMU_OpenTeleporter(true)
-			end)
+			if not IsConsoleUI() then
+				BMU_chatButtonTex = wm:CreateControl("Teleporter_CHAT_MENU_BUTTON", zo_ChatWindow, CT_TEXTURE) --CHG251229 Baertram Performance improvedment for multiple used variable
+	            BMU.chatButtonTex = BMU_chatButtonTex --INS251229 Baertram
+				BMU_chatButtonTex:SetDimensions(33, 33)  --CHG251229 Baertram
+				BMU_chatButtonTex:SetAnchor(TOPRIGHT, zo_ChatWindow, TOPRIGHT, -40 - BMU_svAcc.chatButtonHorizontalOffset, 6) --CHG251229 Baertram
+				BMU_chatButtonTex:SetTexture(BMU_textures_wayshrineBtn) --CHG251229 Baertram
+				BMU_chatButtonTex:SetMouseEnabled(true) --CHG251229 Baertram
+				BMU_chatButtonTex:SetDrawLayer(2) --CHG251229 Baertram
+				--Handlers
+				BMU_chatButtonTex:SetHandler("OnMouseUp", function(self, button) --CHG251229 Baertram
+					if button ~= MOUSE_BUTTON_INDEX_LEFT then return end  --INS BAERTRAM20260124
+					BMU_OpenTeleporter(true)
+				end)
+				
+				BMU_chatButtonTex:SetHandler("OnMouseEnter", function(chatButtonTexCtrl) --CHG251229 Baertram
+					chatButtonTexCtrl:SetTexture(BMU_textures_wayshrineBtnOver) --CHG251229 Baertram
+					BMU_tooltipTextEnter(BMU, chatButtonTexCtrl, appName) --CHG251229 Baertram Performance improvement for multiple called same function, respecting : notation (1st passed in param must be the BMU table then)
+				end)
 			
-			BMU_chatButtonTex:SetHandler("OnMouseEnter", function(chatButtonTexCtrl) --CHG251229 Baertram
-				chatButtonTexCtrl:SetTexture(BMU_textures_wayshrineBtnOver) --CHG251229 Baertram
-				BMU_tooltipTextEnter(BMU, chatButtonTexCtrl, appName) --CHG251229 Baertram Performance improvement for multiple called same function, respecting : notation (1st passed in param must be the BMU table then)
-			end)
-		
-			BMU_chatButtonTex:SetHandler("OnMouseExit", function(chatButtonTexCtrl) --CHG251229 Baertram
-				chatButtonTexCtrl:SetTexture(BMU_textures_wayshrineBtn) --CHG251229 Baertram
-				BMU_tooltipTextEnter(BMU, chatButtonTexCtrl) --CHG251229 Baertram Performance improvement for multiple called same function, respecting : notation (1st passed in param must be the BMU table then)
-			end)
+				BMU_chatButtonTex:SetHandler("OnMouseExit", function(chatButtonTexCtrl) --CHG251229 Baertram
+					chatButtonTexCtrl:SetTexture(BMU_textures_wayshrineBtn) --CHG251229 Baertram
+					BMU_tooltipTextEnter(BMU, chatButtonTexCtrl) --CHG251229 Baertram Performance improvement for multiple called same function, respecting : notation (1st passed in param must be the BMU table then)
+				end)
+			end
 		end
 	end
 	

--- a/BeamMeUp/core/TeleAppUI.lua
+++ b/BeamMeUp/core/TeleAppUI.lua
@@ -94,7 +94,7 @@ local BMU_SOURCE_INDEX_ALL = BMU.SOURCE_INDEX_ALL
 
 --Subtypes
 local clueData = teleporterVars.clueData
-local subTypeClue                 = clueData.clueTypes[1] --"clue"
+local subType_Clue                 = clueData.clueTypes[1] --"clue"
 --Treasure
 local treasureData = teleporterVars.treasureData
 local treasureTypes = treasureData.treasureTypes


### PR DESCRIPTION
This pull request merges the changes that were already deployed to console into the 4.0.2 branch.  Only the clue and the gamepad settings changes are relevant for PC.

Changes included:
* Fix console automation
* Move LibZone to PCDependsOn and load it before globals on console
* Do not run "chat button" code on Console
* Also fix a user-reported bug with subType_Clue not being correctly renamed
* Move specifically Gamepad settings from Addons 2 to Addons leaving only Console settings with LibHarvensAddonSettings